### PR TITLE
Travis - Install Composer and update PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 
 language: php
 php:
-  - 5.3
+  - 5.4
 
 before_script:
   - curl -sS https://getcomposer.org/installer | php

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,8 @@ language: php
 php:
   - 5.3
 
+before_script:
+  - curl -sS https://getcomposer.org/installer | php
+
 script: make
 


### PR DESCRIPTION
After removing composer binary from the repo, Travis build was failing. Added composer install step to travis.yml

Travis minimum PHP version (5.3) was causing composer requirements to fail, bumped to PHP 5.4